### PR TITLE
Add Portuguese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@
 - [Spanish](/i18n/es.yml) by [Ricardo Félix Virto](https://github.com/riki-felix)
 - [Norwegian (Bokmål)](/i18n/no-nb.yml) by [Bear Hagen](https://github.com/bearhagen)
 - [Norwegian (Nynorsk)](/i18n/no-ny.yml) by [Bear Hagen](https://github.com/bearhagen)
+- [Portuguese (Portugal)](/i18n/pt.yml) by [Paulo Pereira](https://github.com/paulozoom)

--- a/i18n/pt.yml
+++ b/i18n/pt.yml
@@ -1,0 +1,15 @@
+description: Português
+invoice:
+  invoice: Factura
+  prepared_for: Facturado a # label for client’s name & address
+  from: De # label for sender’s name & address
+  line_items:
+    description: Descrição
+    quantity: Quantidade
+    rate: Preço
+    tax: Imposto
+    total: Total
+  tax_total: Impostos
+  subtotal: Soma
+  total_due: A Pagar
+  payment_due: Vencimento


### PR DESCRIPTION
One detail: I translated “rate” as price, because I can’t find an ideal word for it. There’s the word “honorário(s)” which is too formal. There’s the word “taxa”, but that can mean fee, or tax, so that would be confusing. I settled on “preço” (price) as it’s the simplest non-confusing word.
