### PR TITLE
Added to FR translation: "Paid" and "Discount"

### DIFF
--- a/i18n/fr.yml
+++ b/i18n/fr.yml
@@ -13,3 +13,5 @@ invoice:
   subtotal: Sous-total
   total_due: Montant dû
   payment_due: Date d'échéance
+  discount: Réduction
+  paid: Payée


### PR DESCRIPTION
Just a heads up: The words for "amount" and "invoice" don't have the same gender in French.

This means "Payée" is feminine because it's about the invoice (**la** facture). If it was about the amount (**le** montant) the word would be "Payé", masculine.

Worth knowing if you plan on using the same key for "paid" in the future.
