### PR TITLE
Add Discount & Paid to German Locale

### DIFF
--- a/i18n/de.yml
+++ b/i18n/de.yml
@@ -1,7 +1,7 @@
 description: German
 invoice:
   invoice: Rechnung
-  prepared_for: Freundlich berechnet für # label for client’s name & address
+  prepared_for: Ausgestellt für # label for client’s name & address
   from: Von # label for sender’s name & address
   line_items:
     description: Beschreibung
@@ -13,3 +13,5 @@ invoice:
   subtotal: Zwischensumme
   total_due: Rechnungssumme
   payment_due: Zahlbar bis
+  discount: Rabatt
+  paid: Bezahlt


### PR DESCRIPTION
Also introduces a minor change in the translation for ”Prepared for“. See https://github.com/cushion/invoice-translations/issues/27
