### PR TITLE
Rename invoice title (en-NZ)

### DIFF
--- a/i18n/en-nz.yml
+++ b/i18n/en-nz.yml
@@ -1,6 +1,6 @@
 description: English (New Zealand)
 invoice:
-  invoice: GST Invoice
+  invoice: Tax Invoice
   prepared_for: Prepared For # label for client’s name & address
   from: From # label for sender’s name & address
   line_items:


### PR DESCRIPTION
As if it wasn't confusing enough, the invoice titles must mention "Tax" and not "GST", despite the tax itself being called "GST". This PR changes the invoice title to "Tax Invoice" but retains "GST" as the tax identifier.